### PR TITLE
add depentency to doctrine/doctrine-bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "symfony/lock": "^3.4||^4.0",
         "symfony/options-resolver": "^3.4||^4.0",
         "symfony/validator": "^3.4||^4.0",
-        "symfony/yaml": "^3.4||^4.0"
+        "symfony/yaml": "^3.4||^4.0",
+        "doctrine/doctrine-bundle": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.15",


### PR DESCRIPTION
When installing this bundle in Symfony project without `doctrine/doctrine-bundle` this error is displayed

```
In Container.php line 277:

  You have requested a non-existent service "doctrine.dbal.default_connection". 
```

`doctrine.dbal.default_connection` service is provided by `doctrine/doctrine-bundle`

Affected versions: dev-master, 1.x