### PR TITLE
catch all error

### DIFF
--- a/src/DataflowType/Dataflow/Dataflow.php
+++ b/src/DataflowType/Dataflow/Dataflow.php
@@ -63,7 +63,7 @@ class Dataflow implements DataflowInterface
         foreach ($this->reader as $index => $item) {
             try {
                 $this->processItem($item);
-            } catch (\Exception $e) {
+            } catch (\Throwable $e) {
                 $exceptions[$index] = $e;
             }
 


### PR DESCRIPTION
When the dataflow is processed, only the Exception is caught but some error can be occurred and can be caught with Throwable.