### PR TITLE
display errors catched during processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Added CollectionWriter and DelegatorWriter
 * Adding Symfony 5.0 compatibility
+* Save all exceptions caught in the log for `code-rhapsodie:dataflow:execute`
 
 # Version 2.0.0
 

--- a/src/Command/ExecuteDataflowCommand.php
+++ b/src/Command/ExecuteDataflowCommand.php
@@ -6,6 +6,7 @@ namespace CodeRhapsodie\DataflowBundle\Command;
 
 use CodeRhapsodie\DataflowBundle\Factory\ConnectionFactory;
 use CodeRhapsodie\DataflowBundle\Registry\DataflowTypeRegistryInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -27,12 +28,18 @@ class ExecuteDataflowCommand extends Command
     /** @var ConnectionFactory */
     private $connectionFactory;
 
-    public function __construct(DataflowTypeRegistryInterface $registry, ConnectionFactory $connectionFactory)
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(DataflowTypeRegistryInterface $registry, ConnectionFactory $connectionFactory, LoggerInterface $logger)
     {
         parent::__construct();
 
         $this->registry = $registry;
         $this->connectionFactory = $connectionFactory;
+        $this->logger = $logger;
     }
 
     /**
@@ -71,6 +78,13 @@ EOF
         $output->writeln('Start time: '.$result->getStartTime()->format('Y/m/d H:i:s'));
         $output->writeln('End time: '.$result->getEndTime()->format('Y/m/d H:i:s'));
         $output->writeln('Success: '.$result->getSuccessCount());
+
+        if ($result->hasErrors()> 0)
+        {
+            foreach ($result->getExceptions() as $e) {
+                $this->logger->error('Error during processing : '.$e->getMessage(), ['exception'=>$e]);
+            }
+        }
 
         return 0;
     }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -23,6 +23,7 @@ services:
         arguments:
             $registry: '@CodeRhapsodie\DataflowBundle\Registry\DataflowTypeRegistryInterface'
             $connectionFactory: '@CodeRhapsodie\DataflowBundle\Factory\ConnectionFactory'
+            $logger: '@logger'
         tags: ['console.command']
 
     CodeRhapsodie\DataflowBundle\Command\JobShowCommand:


### PR DESCRIPTION
`code-rhapsodie:dataflow:execute` command is used during the development process. But no data are save into databases or displayed at end of dataflow processing.

This PR adds to log all exceptions caught during processing only for the command `code-rhapsodie:dataflow:execute`.

The user can get more detail with `-vvv` console argument.