### PR TITLE
Fix for symfony5 compatibility

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -11,8 +11,8 @@ class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('code_rhapsodie_dataflow');
+        $treeBuilder = new TreeBuilder('code_rhapsodie_dataflow');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
The TreeBuilder first constructor parameter must be set to define de root node.