### PR TITLE
Fix bug DateTime Oneshot

### DIFF
--- a/src/Entity/Job.php
+++ b/src/Entity/Job.php
@@ -68,8 +68,6 @@ class Job
 
     /**
      * @var \DateTimeInterface|null
-     *
-     * @Asserts\DateTime()
      */
     private $requestedDate;
 


### PR DESCRIPTION
Remove Annotation @Assert \DateTime because this constraint doesn't support type of DateTime.