### PR TITLE
Update Kudos Github Action to support generation from source repo only

### DIFF
--- a/.github/workflows/semicolons-kudos.yaml
+++ b/.github/workflows/semicolons-kudos.yaml
@@ -11,14 +11,16 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: LoremLabs/kudos-for-code-action@latest
         with:
           search-dir: "."
           destination: "artifact"
           generate-nomerges: true
           generate-validemails: true
-          generate-limitdepth: 1
+          generate-limitdepth: 0
           generate-fromrepo: true
-          analyze-repo: true
+          analyze-repo: false
           skip-ids: ""

--- a/.github/workflows/semicolons-kudos.yaml
+++ b/.github/workflows/semicolons-kudos.yaml
@@ -2,7 +2,7 @@
 name: Kudos for Code
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:
@@ -11,16 +11,14 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v2
       - uses: LoremLabs/kudos-for-code-action@latest
         with:
           search-dir: "."
           destination: "artifact"
           generate-nomerges: true
           generate-validemails: true
-          generate-limitdepth: 0
+          generate-limitdepth: 2
           generate-fromrepo: true
           analyze-repo: false
           skip-ids: ""

--- a/.github/workflows/semicolons-kudos.yaml
+++ b/.github/workflows/semicolons-kudos.yaml
@@ -2,7 +2,7 @@
 name: Kudos for Code
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
           destination: "artifact"
           generate-nomerges: true
           generate-validemails: true
-          generate-limitdepth: 0
+          generate-limitdepth: 2
           generate-fromrepo: true
           analyze-repo: false
           skip-ids: ""

--- a/.github/workflows/semicolons-kudos.yaml
+++ b/.github/workflows/semicolons-kudos.yaml
@@ -2,7 +2,7 @@
 name: Kudos for Code
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   workflow_dispatch:
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
           destination: "artifact"
           generate-nomerges: true
           generate-validemails: true
-          generate-limitdepth: 2
+          generate-limitdepth: 0
           generate-fromrepo: true
           analyze-repo: false
           skip-ids: ""

--- a/.github/workflows/semicolons-kudos.yaml
+++ b/.github/workflows/semicolons-kudos.yaml
@@ -2,7 +2,7 @@
 name: Kudos for Code
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
   workflow_dispatch:
 
 jobs:
@@ -11,14 +11,16 @@ jobs:
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: LoremLabs/kudos-for-code-action@latest
         with:
           search-dir: "."
           destination: "artifact"
           generate-nomerges: true
           generate-validemails: true
-          generate-limitdepth: 2
+          generate-limitdepth: 0
           generate-fromrepo: true
           analyze-repo: false
           skip-ids: ""


### PR DESCRIPTION
This PR modifies the `.github/semicolons-kudos.yaml` file to support generation of [Kudos](https://www.kudos.community) only from the top-level contributors and not from included packages.

